### PR TITLE
Fix exception when using /dvc commands in fabric

### DIFF
--- a/fabric/src/main/java/dev/amsam0/voicechatdiscord/FabricPlatform.java
+++ b/fabric/src/main/java/dev/amsam0/voicechatdiscord/FabricPlatform.java
@@ -75,7 +75,7 @@ public class FabricPlatform implements Platform {
     }
 
     public void sendMessage(Player player, String message) {
-        ((ServerPlayerEntity) player.getPlayer()).sendMessage(toNative(mm(message)));
+        ((ServerPlayerEntity) player.getPlayer()).sendMessage(toNative(mm(message)), false);
     }
 
     public String getName(Player player) {


### PR DESCRIPTION
Fixes #89 (java.lang.NoSuchMethodError being thown in sendMessage, causing /dvc start and other commands to break)

Have tested this with versions 1.19.4, 1.20.1, 1.21.1 and 1.21.4
